### PR TITLE
Fix HumanizeHrefTags not working when see tag spans over multiple lines

### DIFF
--- a/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
+++ b/src/Swashbuckle.AspNetCore.SwaggerGen/XmlComments/XmlCommentsTextHelper.cs
@@ -219,7 +219,7 @@ public static partial class XmlCommentsTextHelper
     private const string CodeTagPattern = @"<c>(?<display>.+?)</c>";
     private const string MultilineCodeTagPattern = @"<code>(?<display>.+?)</code>";
     private const string ParaTagPattern = @"<para>(?<display>.+?)</para>";
-    private const string HrefPattern = @"<see href=\""(.*)\"">(.*)<\/see>";
+    private const string HrefPattern = @"<see\s+href=\""([^""]*)\"">\s*(.*?)\s*<\/see>";
     private const string BrPattern = @"(<br ?\/?>)"; // handles <br>, <br/>, <br />
     private const string LineBreaksPattern = @"\r?\n";
     private const string DoubleUpLineBreaksPattern = @"(\r?\n){2,}";
@@ -237,7 +237,7 @@ public static partial class XmlCommentsTextHelper
     [GeneratedRegex(ParaTagPattern, RegexOptions.Singleline)]
     private static partial Regex ParaTag();
 
-    [GeneratedRegex(HrefPattern)]
+    [GeneratedRegex(HrefPattern, RegexOptions.Singleline)]
     private static partial Regex HrefTag();
 
     [GeneratedRegex(BrPattern)]

--- a/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
+++ b/test/Swashbuckle.AspNetCore.SwaggerGen.Test/XmlComments/XmlCommentsTextHelperTests.cs
@@ -142,6 +142,19 @@ A line of text",
         Assert.Equal(expectedOutput, output, false, true);
     }
 
+    [Fact]
+    public void Humanize_SeeMultiLineTag()
+    {
+        const string input = @"
+            <see href=""https://www.iso.org/iso-4217-currency-codes.html"">
+            ISO currency code
+            </see>";
+
+        var output = XmlCommentsTextHelper.Humanize(input);
+
+        Assert.Equal("[ISO currency code](https://www.iso.org/iso-4217-currency-codes.html)", output, false, true);
+    }
+
     [Theory]
     [InlineData("\r\n")]
     [InlineData("\n")]


### PR DESCRIPTION
<!-- Thank you for contributing to Swashbuckle.AspNetCore!  Open source is only as strong as its contributors. -->

# Pull Request

## The issue or feature being addressed
Fixes #3419

<!-- Please include the existing GitHub issue number where relevant, e.g. "Fixes #123" -->

## Details on the issue fix or feature implementation
Updated the regex to:

```csharp 
@"<see\s+href=\""([^""]*)\"">\s*(.*?)\s*<\/see>"
```

`<see\s+href=` accounts for optional whitespace.
`RegexOptions.Singleline` to allow `.` to match line breaks.
non-greedy `.*?` and` \s*` to trim leading/trailing whitespace (e.g., newlines)

<!-- Information about your changes -->
